### PR TITLE
#Keren APIV2GLEntry Update

### DIFF
--- a/HeliosApp/src/Modifications/Pages/APIV2GLEntry.Page.al
+++ b/HeliosApp/src/Modifications/Pages/APIV2GLEntry.Page.al
@@ -363,17 +363,13 @@ page 50013 "APIV2 - G/L Entry"
                 {
                     Caption = 'Source Name';
                 }
-                field("CurrencyCode"; Rec."Currency Code")
+                field("SourceCurrencyCode"; Rec."Source Currency Code")
                 {
-                    Caption = 'Currency Code';
+                    Caption = 'Source Currency Code';
                 }
-                field("CurrencyFactor"; Rec."Currency Factor")
+                field("SourceCurrencyAmount"; Rec."Source Currency Amount")
                 {
-                    Caption = 'Currency Factor';
-                }
-                field("AmountFCY"; Rec."Amount FCY")
-                {
-                    Caption = 'Amount FCY';
+                    Caption = 'Source Currency Amount';
                 }
                 field("Proforma"; Rec.BCIL_Proforma)
                 {


### PR DESCRIPTION
Update due to error - Dynamics 365 Business Central environment Production could not be updated to version 25.0 because one or more of the installed extensions is not compatible.

Update required:
APIV2GLEntry.Page.al:
1) Currency Code -> Source Currency Code
2) Amount FCY -> Source Currency Amount
3) Currency factor – NA
